### PR TITLE
Added Anaconda secrets to conda publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           python-version: '3.9'
           meta_yaml_dir: .conda
-          user: bschroeter
+          user: ${{ secrets.ANACONDA_USER }}
           label: main
-          token: ${{ secrets.ANACONDA_TOKEN_BEN }}
+          token: ${{ secrets.ANACONDA_TOKEN }}


### PR DESCRIPTION
Added anaconda secrets variables to the workflow file. This allows us to change the anaconda credentials without changing the code itself, while also providing some semblance of security.

I'll add this secret to the repo as well for good measure.