### PR TITLE
Parallel file upload implementation. Fixes #42

### DIFF
--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -124,6 +124,19 @@ def file_upload(file_path):
         click.echo(f.get("file"))
 
 
+@click.command("upload_parallel")
+@click.argument("file_paths", nargs=-1)
+@click.option(
+    "-n", default=2, help="Number of simultaneous parallel uploads (default=2)."
+)
+def file_upload_parallel(file_paths, n=2):
+    client = _get_client()
+    responses = _call(client.upload_files_parallel, files=list(file_paths), n=n)
+    print(responses)
+    for response in responses:
+        click.echo(response.get("data").get("files")[0].get("file"))
+
+
 @click.command("list")
 @click.argument("id")
 def file_list(id):
@@ -250,6 +263,7 @@ def cli_analysis():
 # Add file commands
 cli_file.add_command(file_list)
 cli_file.add_command(file_upload)
+cli_file.add_command(file_upload_parallel)
 cli_file.add_command(file_attach)
 
 # Add endpoint commands

--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import json
 
 
-def _get_client():
+def _get_client() -> Client:
     """Get an authenticated client.
 
     Returns
@@ -45,7 +45,7 @@ def _get_client():
     )
 
 
-def _call(func, **kwargs):
+def _call(func: callable, **kwargs) -> dict:
     """Simple wrapper to handle exceptions.
 
     Exceptions are captured broadly and raw error message printed before non-zero exit.
@@ -109,7 +109,7 @@ def list_endpoints():
 
 @click.command("upload")
 @click.argument("file_path", nargs=-1)
-def file_upload(file_path):
+def file_upload(file_path: tuple):
     """
     Upload a file to the server.
 
@@ -129,17 +129,25 @@ def file_upload(file_path):
 @click.option(
     "-n", default=2, help="Number of simultaneous parallel uploads (default=2)."
 )
-def file_upload_parallel(file_paths, n=2):
+def file_upload_parallel(file_paths: tuple, n: int = 2):
+    """Upload files in parallel.
+
+    Parameters
+    ----------
+    file_paths : tuple
+        Sequence of file paths.
+    n : int, optional
+        Number of parallel uploads, by default 2
+    """
     client = _get_client()
     responses = _call(client.upload_files_parallel, files=list(file_paths), n=n)
-    print(responses)
     for response in responses:
         click.echo(response.get("data").get("files")[0].get("file"))
 
 
 @click.command("list")
 @click.argument("id")
-def file_list(id):
+def file_list(id: str):
     """
     List the files currently attached to a model output.
 
@@ -155,7 +163,7 @@ def file_list(id):
 @click.command("attach")
 @click.argument("file_id")
 @click.argument("output_id")
-def file_attach(file_id, output_id):
+def file_attach(file_id: str, output_id: str):
     """
     Attach a file to a model output.
     """
@@ -168,7 +176,7 @@ def file_attach(file_id, output_id):
 
 @click.command("start")
 @click.argument("id")
-def analysis_start(id):
+def analysis_start(id: str):
     """
     Start the analysis for the model output id.
 
@@ -185,7 +193,7 @@ def analysis_start(id):
 
 @click.command("status")
 @click.argument("id")
-def analysis_status(id):
+def analysis_status(id: str):
     """
     Get the status of the analysis.
 
@@ -212,7 +220,7 @@ def analysis_status(id):
 @click.option(
     "--dev", is_flag=True, default=False, help="Setup for the development server."
 )
-def initialise(dev=False):
+def initialise(dev: bool = False):
     """
     Initialise the client on the system.
     """
@@ -229,7 +237,7 @@ def initialise(dev=False):
         click.echo(ex.msg, err=True)
         sys.exit(1)
 
-    print("Connection established.")
+    click.echo("Connection established.")
 
     # Build out the dictionary and save it to the user home.
     credentials = dict(email=email, password=password)

--- a/meorg_client/client.py
+++ b/meorg_client/client.py
@@ -12,6 +12,7 @@ import meorg_client.exceptions as mx
 import meorg_client.utilities as mu
 import mimetypes as mt
 from pathlib import Path
+from multiprocessing import Pool
 
 
 class Client:
@@ -215,6 +216,36 @@ class Client:
         if response.status_code == 200:
             self.headers.pop("X-User-Id", None)
             self.headers.pop("X-Auth-Token", None)
+
+    def upload_files_parallel(self, files: list, n: int = 2):
+        """Upload files in parallel.
+
+        Parameters
+        ----------
+        files : list
+            List of file paths.
+        n : int, optional
+            Number of threads to use, by default 2
+
+        Returns
+        -------
+        list
+            List of dicts or response objects from upload_files.
+        """
+
+        # Ensure the object is actually iterable
+        files = mu.ensure_list(files)
+
+        # Sequential case, single file provided
+        if len(files) == 1:
+            return self.upload_files(files)
+
+        # Do the parallel upload
+        responses = None
+        with Pool(processes=n) as pool:
+            responses = pool.map(self.upload_files, files)
+
+        return responses
 
     def upload_files(
         self,

--- a/meorg_client/client.py
+++ b/meorg_client/client.py
@@ -128,7 +128,7 @@ class Client:
         # For flexibility
         return self.last_response
 
-    def _get_url(self, endpoint, **kwargs):
+    def _get_url(self, endpoint: str, **kwargs):
         """Get the well-formed URL for the call.
 
         Parameters
@@ -217,15 +217,15 @@ class Client:
             self.headers.pop("X-User-Id", None)
             self.headers.pop("X-Auth-Token", None)
 
-    def upload_files_parallel(self, files: list, n: int = 2):
+    def upload_files_parallel(self, files: Union[str, Path, list], n: int = 2):
         """Upload files in parallel.
 
         Parameters
         ----------
-        files : list
-            List of file paths.
+        files : Union[str, Path, list]
+            A path to a file, or a list of paths.
         n : int, optional
-            Number of threads to use, by default 2
+            Number of threads to use, by default 2.
 
         Returns
         -------
@@ -236,7 +236,7 @@ class Client:
         # Ensure the object is actually iterable
         files = mu.ensure_list(files)
 
-        # Sequential case, single file provided
+        # Single file provided, don't bother starting the pool
         if len(files) == 1:
             return self.upload_files(files)
 
@@ -410,7 +410,7 @@ class Client:
         """
         return self._make_request(method=mcc.HTTP_GET, endpoint=endpoints.ENDPOINT_LIST)
 
-    def success(self):
+    def success(self) -> bool:
         """Test if the last request was successful.
 
         Returns

--- a/meorg_client/tests/test_cli.py
+++ b/meorg_client/tests/test_cli.py
@@ -48,6 +48,15 @@ def test_file_multiple(runner):
     time.sleep(5)
 
 
+def test_file_upload_parallel(runner):
+    """Test file-upload via CLI."""
+
+    # Upload a tiny test file
+    filepath = os.path.join(mu.get_installed_data_root(), "test/test.txt")
+    result = runner.invoke(cli.file_upload_parallel, [filepath, filepath, "-n 2"])
+    assert result.exit_code == 0
+
+
 def test_file_list(runner):
     """Test file-list via CLI."""
     result = runner.invoke(cli.file_list, [store.get("model_output_id")])

--- a/meorg_client/tests/test_cli.py
+++ b/meorg_client/tests/test_cli.py
@@ -8,22 +8,40 @@ import time
 
 
 @pytest.fixture
-def runner():
+def runner() -> CliRunner:
+    """Get a runner object.
+
+    Returns
+    -------
+    click.testing.CliRunner
+        Runner object.
+    """
     return CliRunner()
 
 
-def test_list_endpoints(runner):
+@pytest.fixture
+def test_filepath() -> str:
+    """Get a test filepath from the installation.
+
+    Returns
+    -------
+    str
+        Path to the test filepath.
+    """
+    return os.path.join(mu.get_installed_data_root(), "test/test.txt")
+
+
+def test_list_endpoints(runner: CliRunner):
     """Test list-endpoints via CLI."""
     result = runner.invoke(cli.list_endpoints)
     assert result.exit_code == 0
 
 
-def test_file_upload(runner):
+def test_file_upload(runner: CliRunner, test_filepath: str):
     """Test file-upload via CLI."""
 
     # Upload a tiny test file
-    filepath = os.path.join(mu.get_installed_data_root(), "test/test.txt")
-    result = runner.invoke(cli.file_upload, [filepath])
+    result = runner.invoke(cli.file_upload, [test_filepath])
     assert result.exit_code == 0
 
     # Add the job_id to the store for the next test
@@ -33,12 +51,11 @@ def test_file_upload(runner):
     time.sleep(5)
 
 
-def test_file_multiple(runner):
+def test_file_multiple(runner: CliRunner, test_filepath: str):
     """Test file-upload via CLI."""
 
     # Upload a tiny test file
-    filepath = os.path.join(mu.get_installed_data_root(), "test/test.txt")
-    result = runner.invoke(cli.file_upload, [filepath, filepath])
+    result = runner.invoke(cli.file_upload, [test_filepath, test_filepath])
     assert result.exit_code == 0
 
     # Add the job_id to the store for the next test
@@ -48,12 +65,13 @@ def test_file_multiple(runner):
     time.sleep(5)
 
 
-def test_file_upload_parallel(runner):
+def test_file_upload_parallel(runner: CliRunner, test_filepath: str):
     """Test file-upload via CLI."""
 
     # Upload a tiny test file
-    filepath = os.path.join(mu.get_installed_data_root(), "test/test.txt")
-    result = runner.invoke(cli.file_upload_parallel, [filepath, filepath, "-n 2"])
+    result = runner.invoke(
+        cli.file_upload_parallel, [test_filepath, test_filepath, "-n 2"]
+    )
     assert result.exit_code == 0
 
 

--- a/meorg_client/tests/test_client.py
+++ b/meorg_client/tests/test_client.py
@@ -144,6 +144,20 @@ def test_upload_file_large(client):
     assert client.success()
 
 
+def test_upload_file_parallel(client):
+    """Test the uploading of a file."""
+    # Upload the file.
+    filepath = os.path.join(mu.get_installed_data_root(), "test/test.txt")
+
+    # Upload the file
+    responses = client.upload_files_parallel([filepath, filepath], n=2)
+
+    # Make sure it worked
+    assert all(
+        [response.get("data").get("files")[0].get("file") for response in responses]
+    )
+
+
 def test_logout(client):
     """Test logout."""
     client.logout()


### PR DESCRIPTION
Following from #41, the client now implements a parallel upload option. This will enable us to upload an entire directory of outputs more efficiently.

Callable using `client.file_upload_parallel()` method or `meorg file upload_parallel` over CLI.

Tests pass, feel free to post any questions in the discussion.