### PR TITLE
Reconciled upload methods and fixed tests. Fixes #50

### DIFF
--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -109,12 +109,13 @@ def list_endpoints():
 
 @click.command("upload")
 @click.argument("file_path", nargs=-1)
+@click.option("-n", default=1, help="Number of threads for parallel uploads.")
 @click.option(
     "--attach_to",
     default=None,
     help="Supply a model output id to immediately attach the file to.",
 )
-def file_upload(file_path, attach_to=None):
+def file_upload(file_path, n: int = 1, attach_to=None):
     """
     Upload a file to the server.
 
@@ -125,41 +126,23 @@ def file_upload(file_path, attach_to=None):
     client = _get_client()
 
     # Upload the file, get the job ID
-    response = _call(client.upload_files, files=list(file_path), attach_to=attach_to)
+    responses = _call(
+        client.upload_files,
+        files=list(file_path),
+        n=n,
+        attach_to=attach_to,
+        progress=True,
+    )
 
-    # Different logic if we are attaching to a model output immediately
-    if not attach_to:
+    for response in responses:
+
+        # For singular case
+        if n == 1:
+            response = response[0]
+
         files = response.get("data").get("files")
         for f in files:
             click.echo(f.get("file"))
-    else:
-        click.echo("SUCCESS")
-
-
-@click.command("upload_parallel")
-@click.argument("file_paths", nargs=-1)
-@click.option(
-    "-n", default=2, help="Number of simultaneous parallel uploads (default=2)."
-)
-@click.option(
-    "--attach_to",
-    default=None,
-    help="Supply a model output id to immediately attach the file to.",
-)
-def file_upload_parallel(file_paths: tuple, n: int = 2, attach_to: str = None):
-    """Upload files in parallel.
-
-    Parameters
-    ----------
-    file_paths : tuple
-        Sequence of file paths.
-    n : int, optional
-        Number of parallel uploads, by default 2
-    """
-    client = _get_client()
-    responses = _call(client.upload_files_parallel, files=list(file_paths), n=n)
-    for response in responses:
-        click.echo(response.get("data").get("files")[0].get("file"))
 
 
 @click.command("list")
@@ -288,7 +271,7 @@ def cli_analysis():
 # Add file commands
 cli_file.add_command(file_list)
 cli_file.add_command(file_upload)
-cli_file.add_command(file_upload_parallel)
+# cli_file.add_command(file_upload_parallel)
 cli_file.add_command(file_attach)
 
 # Add endpoint commands

--- a/meorg_client/tests/test_cli.py
+++ b/meorg_client/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_file_upload(runner: CliRunner, test_filepath: str):
     assert result.exit_code == 0
 
     # Add the job_id to the store for the next test
-    store.set("file_id", result.output.strip())
+    store.set("file_id", result.stdout.split()[-1].strip())
 
     # Let it wait for a short while, allow the server to transfer to object store.
     time.sleep(5)
@@ -63,16 +63,6 @@ def test_file_multiple(runner: CliRunner, test_filepath: str):
 
     # Let it wait for a short while, allow the server to transfer to object store.
     time.sleep(5)
-
-
-def test_file_upload_parallel(runner: CliRunner, test_filepath: str):
-    """Test file-upload via CLI."""
-
-    # Upload a tiny test file
-    result = runner.invoke(
-        cli.file_upload_parallel, [test_filepath, test_filepath, "-n 2"]
-    )
-    assert result.exit_code == 0
 
 
 def test_file_list(runner):
@@ -100,11 +90,19 @@ def test_file_upload_with_attach(runner, test_filepath):
     assert result.exit_code == 0
 
 
+def test_file_upload_parallel(runner: CliRunner, test_filepath: str):
+    """Test file-upload via CLI."""
+
+    # Upload a tiny test file
+    result = runner.invoke(cli.file_upload, [test_filepath, test_filepath, "-n", "2"])
+    assert result.exit_code == 0
+
+
 def test_file_upload_parallel_with_attach(runner, test_filepath):
     """Test file upload with attachment via CLI."""
     model_output_id = store.get("model_output_id")
     result = runner.invoke(
-        cli.file_upload_parallel,
-        [test_filepath, test_filepath, "--attach_to", model_output_id],
+        cli.file_upload,
+        [test_filepath, test_filepath, "-n", "2", "--attach_to", model_output_id],
     )
     assert result.exit_code == 0

--- a/meorg_client/tests/test_client.py
+++ b/meorg_client/tests/test_client.py
@@ -77,7 +77,7 @@ def test_list_endpoints(client: Client):
 def test_upload_file(client: Client, test_filepath: str):
     """Test the uploading of a file."""
     # Upload the file
-    response = client.upload_files(test_filepath)
+    response = client.upload_files(test_filepath)[0]
 
     # Make sure it worked
     assert client.success()
@@ -108,7 +108,7 @@ def test_file_list(client: Client):
 
 def test_attach_files_to_model_output(client: Client):
     # Get the file id from the job id
-    file_id = store.get("file_upload").get("data").get("files")[0].get("file")
+    file_id = store.get("file_upload")[0].get("data").get("files")[0].get("file")
 
     # Attach it to the model output
     _ = client.attach_files_to_model_output(client._model_output_id, [file_id])
@@ -165,7 +165,18 @@ def test_upload_files_with_attach(client: Client):
 def test_upload_file_parallel(client: Client, test_filepath: str):
     """Test the uploading of a file."""
     # Upload the file
-    responses = client.upload_files_parallel([test_filepath, test_filepath], n=2)
+    responses = client.upload_files([test_filepath, test_filepath], n=2, progress=True)
+
+    # Make sure it worked
+    assert all(
+        [response.get("data").get("files")[0].get("file") for response in responses]
+    )
+
+
+def test_upload_file_parallel_no_progress(client: Client, test_filepath: str):
+    """Test the uploading of a file."""
+    # Upload the file
+    responses = client.upload_files([test_filepath, test_filepath], n=2, progress=False)
 
     # Make sure it worked
     assert all(
@@ -176,7 +187,7 @@ def test_upload_file_parallel(client: Client, test_filepath: str):
 def test_upload_file_parallel_with_attach(client: Client, test_filepath: str):
     """Test the uploading of a file with a model output ID to attach."""
     # Upload the file
-    responses = client.upload_files_parallel(
+    responses = client.upload_files(
         [test_filepath, test_filepath], n=2, attach_to=client._model_output_id
     )
 


### PR DESCRIPTION
A non-trivial refactor which allows the user to use the one upload method with arguments to farm out functionality to parallel uploads.

Tests were tricky, but appear to pass.

We also get a progress bar, which allows us to monitor uploads of lots of files.