### PR TITLE
Added routines to detach all files from a model output. Fixes #52

### DIFF
--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -191,6 +191,21 @@ def file_attach(file_id: str, output_id: str):
     click.echo("SUCCESS")
 
 
+@click.command("detach_all")
+@click.argument("output_id")
+def file_detach_all(output_id: str):
+    """Detach all files from a model output.
+
+    Parameters
+    ----------
+    output_id : str
+        Model output ID.
+    """
+    client = _get_client()
+    _ = _call(client.detach_all_files_from_model_output, id=output_id)
+    click.echo("SUCCESS")
+
+
 @click.command("start")
 @click.argument("id")
 def analysis_start(id: str):

--- a/meorg_client/client.py
+++ b/meorg_client/client.py
@@ -375,6 +375,30 @@ class Client:
             json=new_files,
         )
 
+    def detach_all_files_from_model_output(
+        self, id: str
+    ) -> Union[dict, requests.Response]:
+        """Detach all files from a model output.
+
+        Parameters
+        ----------
+        id : str
+            Model output ID.
+
+        Returns
+        -------
+        Union[dict, requests.Response]
+            Response from ME.org
+        """
+
+        # Update the resource with an empty file list
+        return self._make_request(
+            mcc.HTTP_PATCH,
+            endpoint=endpoints.FILE_LIST,
+            url_params=dict(id=id),
+            json=[],
+        )
+
     def start_analysis(self, id: str) -> Union[dict, requests.Response]:
         """Start the analysis chain.
 

--- a/meorg_client/tests/test_cli.py
+++ b/meorg_client/tests/test_cli.py
@@ -108,3 +108,13 @@ def test_file_upload_parallel_with_attach(runner, test_filepath):
         [test_filepath, test_filepath, "--attach_to", model_output_id],
     )
     assert result.exit_code == 0
+
+
+def test_detach_all(runner):
+    """Test detaching all files from a model output."""
+    model_output_id = store.get("model_output_id")
+    result = runner.invoke(
+        cli.file_detach_all,
+        [model_output_id],
+    )
+    assert result.exit_code == 0

--- a/meorg_client/tests/test_client.py
+++ b/meorg_client/tests/test_client.py
@@ -186,6 +186,17 @@ def test_upload_file_parallel_with_attach(client: Client, test_filepath: str):
     )
 
 
+def test_detach_all_files_from_model_output(client: Client):
+    """Test detaching all files from a model output."""
+
+    # Remove them all
+    _ = client.detach_all_files_from_model_output(client._model_output_id)
+    detached_files = client.list_files(client._model_output_id)
+
+    assert client.last_response.ok
+    assert len(detached_files.get("data").get("files")) == 0
+
+
 def test_logout(client: Client):
     """Test logout."""
     client.logout()


### PR DESCRIPTION
As described. Files can now be detached from a model output (allowing us to keep using it with new files rather than having to recreate it.)

Note: These files still exist on the server somewhere, I aim working with UNSW for a solution to garbage collect anything that has no associated model output.