### PR TITLE
(#59) - Add tqdm to conda dependencies

### DIFF
--- a/.conda/meorg_client_dev.yaml
+++ b/.conda/meorg_client_dev.yaml
@@ -16,5 +16,6 @@ dependencies:
   - black
   - ruff
   - pandas>=2.2.2
+  - tqdm>=4.66.5
   - pip:
     - -r mkdocs-requirements.txt

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - click >=8.1.7
     - PyYAML >=6.0.1
     - pandas >=2.2.2
+    - tqdm>=4.66.5
 
 test:
   imports:


### PR DESCRIPTION
I have checked the meorg_client_dev environment builds with the added dependency. I don't know how to check if meorg_client works in the environment, do you want to check anything?