### PR TITLE
Create model output endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         MEORG_EMAIL: ${{ secrets.MEORG_EMAIL }}
         MEORG_PASSWORD: ${{ secrets.MEORG_PASSWORD }}
         MEORG_MODEL_OUTPUT_ID: ${{ secrets.MEORG_MODEL_OUTPUT_ID }}
+        MEORG_MODEL_OUTPUT_NAME: ${{ secrets.MEORG_MODEL_OUTPUT_NAME}}
+        MEORG_MODEL_PROFILE_ID: ${{ secrets.MEORG_MODEL_PROFILE_ID }}
+        MEORG_EXPERIMENT_ID: ${{ secrets.MEORG_EXPERIMENT_ID }}
       run: |
         conda install pytest
         pytest -v

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,6 +93,39 @@ modelevaluation.org/modelOutput/display/**kafS53HgWu2CDXxgC**
 
 This command will return an `$ANALYSIS_ID` upon success which is used in `analysis status`.
 
+### model output create
+
+To create a model output, execute the following command:
+
+```shell
+meorg output create $MODEL_PROFILE_ID $EXPERIMENT_ID $MODEL_OUTPUT_NAME
+```
+
+Where `$MODEL_PROFILE_ID` and `$EXPERIMENT_ID` are found on the model profile and corresponding experiment details pages on modelevaluation.org. `$MODEL_OUTPUT_NAME` is a unique name for the newly created model output.
+
+This command will return the newly created `$MODEL_OUTPUT_ID` upon success which is used for further analysis. It will also print whether an existing model output record was overwritten.
+
+### model output query
+
+Retrieve Model output details via `$MODEL_OUTPUT_ID`
+
+```shell
+meorg output query $MODEL_OUTPUT_ID
+```
+
+This command will print the `id` and `name` of the modeloutput. If developer mode is enabled, print the JSON representation for the model output with metadata. An example model output data response would be:
+
+```json
+{
+    "id": "MnCj3tMzGx3NsuzwS",
+    "name": "temp-output",
+    "created": "2025-04-04T00:09:44.258Z",
+    "modified": "2025-04-17T05:12:08.135Z",
+    "stateSelection": "default model initialisation",
+    "benchmarks": []
+}
+```
+
 ### analysis status
 
 To query the status of an analysis, execute the following command:

--- a/meorg_client/constants.py
+++ b/meorg_client/constants.py
@@ -1,3 +1,5 @@
+import os
+
 """Constants."""
 
 # Valid HTTP methods

--- a/meorg_client/data/openapi.json
+++ b/meorg_client/data/openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.1.0",
     "info": {
         "title": "Modelevaluation REST endpoints",
-        "version": "2.0.0"
+        "version": "2.1.0"
     },
     "servers": [
         {
@@ -41,15 +41,13 @@
                                         "description": "Account password"
                                     }
                                 }
-                            },
-                            "encoding": {
-                                "explode": false
                             }
                         }
                     }
                 },
                 "responses": {
                     "200": {
+                        "description": "Generates API-key pair required for authentication",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -93,6 +91,427 @@
                 "responses": {
                     "200": {
                         "description": "Success"
+                    }
+                }
+            }
+        },
+        "/modeloutput": {
+            "get": {
+                "summary": "Retieve JSON representation from id or unique name",
+                "description": "Query by MO by id or by unique MO name",
+                "tags": [
+                    "Model Outputs"
+                ],
+                "security": [
+                    {
+                        "userId": [],
+                        "authToken": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "description": "Model output id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "description": "Name of model output",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Object may contain the following fields - \"id\", \"created\", \"modified\", \"state_selection\", \"parameter_selection\", \"comments\", \"is_bundle\", \"benchmarks\"",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "modeloutput": {
+                                                    "type": "object",
+                                                    "description": "JSON representation of the modeloutput",
+                                                    "example": {
+                                                        "id": "me5pq77uhy4bjR78",
+                                                        "name": "abc",
+                                                        "benchmarks": [
+                                                            "1",
+                                                            "2",
+                                                            "3"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/unauthorisedResponse"
+                    },
+                    "404": {
+                        "$ref": "#/components/notFound"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new MO entity",
+                "description": "If model output name is existing, and belongs to the current user, the existing MO's id is returned",
+                "tags": [
+                    "Model Outputs"
+                ],
+                "security": [
+                    {
+                        "userId": [],
+                        "authToken": []
+                    }
+                ],
+                "requestBody": {
+                    "description": "Experiment and Model IDs must be existing. Name length restricted to 50 characters",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "experiment",
+                                    "model",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "experiment": {
+                                        "type": "string",
+                                        "description": "The ID of the experiment"
+                                    },
+                                    "model": {
+                                        "type": "string",
+                                        "description": "The ID of the model profile. Note!!! Not to be confused with a model output."
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the model output. Length of 50 max."
+                                    },
+                                    "state_selection": {
+                                        "type": "string",
+                                        "description": "One of \"default model initialisation\", \"model spinup on forcing data\", \"states derived directly from measurements\", or \"other\"",
+                                        "nullable": true
+                                    },
+                                    "parameter_selection": {
+                                        "type": "string",
+                                        "description": "One of \"automated calibration\", \"manual calibration\", or \"no calibration (model default values)\"",
+                                        "nullable": true
+                                    },
+                                    "comments": {
+                                        "type": "string",
+                                        "description": "Additional descriptions about the model output - e.g. configurations",
+                                        "nullable": true
+                                    },
+                                    "is_bundle": {
+                                        "type": "boolean",
+                                        "description": "Indicates if the model output is a bundle. If so, this model output will not be a benchmark option for other analyses",
+                                        "nullable": true
+                                    },
+                                    "benchmarks": {
+                                        "type": "array",
+                                        "description": "List of benchmarks associated with the model output. Benchmarks must be accessible from the associated experiment",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "nullable": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Contains the existing MO Id in data field. It will specify whether an existing record was returned or a new record created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "modeloutput": {
+                                                    "type": "string",
+                                                    "description": "modeloutput ID of created object",
+                                                    "example": "me5pq77uhy4bjR78R"
+                                                },
+                                                "created": {
+                                                    "type": "boolean",
+                                                    "description": "value indicates whether resource was existing or new",
+                                                    "example": false
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/invalidData"
+                    },
+                    "401": {
+                        "$ref": "#/components/unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/unauthorisedResponse"
+                    }
+                }
+            }
+        },
+        "/modeloutput/{id}": {
+            "patch": {
+                "summary": "Update specific fields of an existing MO",
+                "description": "See schema below for detail on fields that may be edited. Note experiments cannot be edited via API.",
+                "tags": [
+                    "Model Outputs"
+                ],
+                "security": [
+                    {
+                        "userId": [],
+                        "authToken": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "description": "Model output id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "description": "Fields that are not included will remain unchanged",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the model output. Length of 50 max.",
+                                        "nullable": true
+                                    },
+                                    "model": {
+                                        "type": "string",
+                                        "description": "The ID of the model profile. Note, not to be confused with a model output",
+                                        "nullable": true
+                                    },
+                                    "state_selection": {
+                                        "type": "string",
+                                        "description": "One of \"default model initialisation\", \"model spinup on forcing data\", \"states derived directly from measurements\", or \"other\"",
+                                        "nullable": true
+                                    },
+                                    "parameter_selection": {
+                                        "type": "string",
+                                        "description": "One of \"automated calibration\", \"manual calibration\", or \"no calibration (model default values)\"",
+                                        "nullable": true
+                                    },
+                                    "comments": {
+                                        "type": "string",
+                                        "description": "Additional descriptions about the model output - e.g. configurations",
+                                        "nullable": true
+                                    },
+                                    "is_bundle": {
+                                        "type": "boolean",
+                                        "description": "Indicates if the model output is a bundle. If so, this model output will not be a benchmark option for other analyses",
+                                        "nullable": true
+                                    },
+                                    "benchmarks": {
+                                        "type": "array",
+                                        "description": "List of benchmarks associated with the model output. Benchmarks must be accessible from the associated experiment",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "nullable": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "data": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "example": null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/invalidData"
+                    },
+                    "401": {
+                        "$ref": "#/components/unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/unauthorisedResponse"
+                    },
+                    "404": {
+                        "$ref": "#/components/notFound"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Remove a MO",
+                "description": "All unique data associated will be deleted - e.g. output files",
+                "tags": [
+                    "Model Outputs"
+                ],
+                "security": [
+                    {
+                        "userId": [],
+                        "authToken": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "description": "Model output id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "data": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "example": null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/unauthorisedResponse"
+                    },
+                    "404": {
+                        "$ref": "#/components/notFound"
+                    }
+                }
+            }
+        },
+        "/modeloutput/{id}/available-benchmarks": {
+            "get": {
+                "summary": "Retrieve related MOs which may be used as a benchmark",
+                "description": "Only model outputs that are used in the same experiment can be designated as a benchmark",
+                "tags": [
+                    "Model Outputs"
+                ],
+                "security": [
+                    {
+                        "userId": [],
+                        "authToken": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "description": "Model output id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns a list of MO ids that may be used as benchmarks",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "benchmarks": {
+                                                    "type": "Array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "description": "modeloutput ID of available benchmark",
+                                                        "example": "me5pq77uhy4bjR78R"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/invalidData"
+                    },
+                    "401": {
+                        "$ref": "#/components/unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/unauthorisedResponse"
                     }
                 }
             }

--- a/meorg_client/endpoints.py
+++ b/meorg_client/endpoints.py
@@ -16,3 +16,7 @@ FILE_STATUS = "files/status/{id}"
 # Analysis
 ANALYSIS_START = "modeloutput/{id}/start"
 ANALYSIS_STATUS = "analysis/{id}/status"
+
+# Model Outputs
+MODEL_OUTPUT_CREATE = "modeloutput"
+MODEL_OUTPUT_QUERY = MODEL_OUTPUT_CREATE

--- a/meorg_client/tests/conftest.py
+++ b/meorg_client/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 # Set dev mode
 os.environ["MEORG_DEV_MODE"] = "1"
@@ -27,3 +28,42 @@ store = ValueStorage()
 store.set("email", os.environ.get("MEORG_EMAIL"))
 store.set("password", os.environ.get("MEORG_PASSWORD"))
 store.set("model_output_id", os.environ.get("MEORG_MODEL_OUTPUT_ID"))
+store.set("experiment_id", os.environ.get("MEORG_EXPERIMENT_ID"))
+store.set("model_profile_id", os.environ.get("MEORG_MODEL_PROFILE_ID"))
+store.set("model_output_name", os.environ.get("MEORG_MODEL_OUTPUT_NAME"))
+
+
+@pytest.fixture
+def model_profile_id() -> str:
+    """Get the experiment ID out of the environment.
+
+    Returns
+    -------
+    str
+        Model Profile ID.
+    """
+    return os.getenv("MEORG_MODEL_PROFILE_ID")
+
+
+@pytest.fixture
+def experiment_id() -> str:
+    """Get the experiment ID out of the environment.
+
+    Returns
+    -------
+    str
+        Experiment ID.
+    """
+    return os.getenv("MEORG_EXPERIMENT_ID")
+
+
+@pytest.fixture
+def model_output_name() -> str:
+    """Get the model output name.
+
+    Returns
+    -------
+    str
+        Model output name.
+    """
+    return os.getenv("MEORG_MODEL_OUTPUT_NAME") or "meorg-client-model-output"

--- a/meorg_client/tests/test_cli.py
+++ b/meorg_client/tests/test_cli.py
@@ -56,6 +56,32 @@ def test_list_endpoints(runner: CliRunner):
     assert result.exit_code == 0
 
 
+def test_create_model_output(
+    runner: CliRunner, model_profile_id, experiment_id, model_output_name
+):
+    """Test Creation of Model output."""
+    result = runner.invoke(
+        cli.create_new_model_output,
+        [model_profile_id, experiment_id, model_output_name],
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0
+    assert type(result.return_value) is str  # The new model output
+
+    # Test newly created model_output_id
+    test_model_output_query(runner, result.return_value)
+
+
+def test_model_output_query(runner: CliRunner, model_output_id: str):
+    """Test Existing Model output."""
+    result = runner.invoke(
+        cli.model_output_query,
+        [model_output_id],
+    )
+    assert result.exit_code == 0
+
+
 def test_file_upload(runner: CliRunner, test_filepath: str, model_output_id: str):
     """Test file-upload via CLI.
 

--- a/meorg_client/tests/test_client.py
+++ b/meorg_client/tests/test_client.py
@@ -93,6 +93,30 @@ def test_list_endpoints(client: Client):
     assert isinstance(response, dict)
 
 
+def test_create_model_output(
+    client: Client, model_profile_id: str, experiment_id: str, model_output_name: str
+):
+    """Test Creation of Model output."""
+    response = client.model_output_create(
+        model_profile_id, experiment_id, model_output_name
+    )
+    assert client.success()
+
+    model_output_id = response.get("data").get("modeloutput")
+    assert model_output_id is not None
+
+    test_model_output_query(client, model_output_id)
+
+
+def test_model_output_query(client: Client, model_output_id: str):
+    """Test Existing Model output."""
+    response = client.model_output_query(model_output_id)
+    assert client.success()
+
+    response_model_output_data = response.get("data").get("modeloutput")
+    assert response_model_output_data.get("id") == model_output_id
+
+
 def test_upload_file(client: Client, test_filepath: str, model_output_id: str):
     """Test the uploading of a file.
 

--- a/meorg_client/utilities.py
+++ b/meorg_client/utilities.py
@@ -101,3 +101,7 @@ def get_uploaded_file_ids(response):
     """
     file_ids = [f.get("file") for f in response.get("data").get("files")]
     return file_ids
+
+
+def is_dev_mode():
+    return os.getenv("MEORG_DEV_MODE", "0") == "1"


### PR DESCRIPTION
Related to #63 

Implement endpoint for creating a new model output (`POST` method) for a given Experiment ID + Model Profile ID

Add Github secrets for the following (following from the existing model output id)

1. `MEORG_MODEL_OUTPUT_NAME` - If no environment variable is provided for `pytest`, `"meorg-client-model-output"` is used
2. `MEORG_MODEL_PROFILE_ID`
3. `MEORG_EXPERIMENT_ID`
