### PR TITLE
meorg_client/client.py: Send data as json for model output create

### DIFF
--- a/meorg_client/client.py
+++ b/meorg_client/client.py
@@ -476,7 +476,7 @@ class Client:
         return self._make_request(
             method=mcc.HTTP_POST,
             endpoint=endpoints.MODEL_OUTPUT_CREATE,
-            data=dict(model=mod_prof_id, name=name) | config_params,
+            json=dict(model=mod_prof_id, name=name) | config_params,
         )
 
     def model_output_query(self, model_id: str) -> Union[dict, requests.Response]:


### PR DESCRIPTION
Upstream has removed the conversion from form-urlencoded payloads to json payloads, causing the `model output create` command to fail. This fixes this by sending the data as json.