### PR TITLE
Add `--name` option to `meorg output query`

### DIFF
--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -325,8 +325,9 @@ def create_new_model_output(
 
 
 @click.command("query")
-@click.argument("model_id")
-def model_output_query(model_id: str):
+@click.option("--name", required=False, help="Name of model output entity.")
+@click.argument("model_id", required=False)
+def model_output_query(model_id: str, name: str):
     """
     Get details for a specific new model output entity
 
@@ -334,13 +335,17 @@ def model_output_query(model_id: str):
     ----------
     model_id : str
         Model Output ID.
-
+    name : str
+        Name of model output entity.
 
     Prints the `id` modeloutput, and JSON representation for the remaining metadata if in dev mode.
     """
     client = _get_client()
 
-    response = _call(client.model_output_query, model_id=model_id)
+    if name:
+        response = _call(client.model_output_query, name=name)
+    else:
+        response = _call(client.model_output_query, model_id=model_id)
 
     if client.success():
 

--- a/meorg_client/cli.py
+++ b/meorg_client/cli.py
@@ -324,7 +324,7 @@ def create_new_model_output(
     return model_output_id
 
 
-@click.command("query")
+@click.command("query", no_args_is_help=True)
 @click.option("--name", required=False, help="Name of model output entity.")
 @click.argument("model_id", required=False)
 def model_output_query(model_id: str, name: str):

--- a/meorg_client/client.py
+++ b/meorg_client/client.py
@@ -479,7 +479,7 @@ class Client:
             json=dict(model=mod_prof_id, name=name) | config_params,
         )
 
-    def model_output_query(self, model_id: str) -> Union[dict, requests.Response]:
+    def model_output_query(self, model_id: str = None, name: bool = None) -> Union[dict, requests.Response]:
         """
         Get details for a specific new model output entity
         Parameters
@@ -495,7 +495,7 @@ class Client:
         return self._make_request(
             method=mcc.HTTP_GET,
             endpoint=endpoints.MODEL_OUTPUT_QUERY,
-            url_params=dict(id=model_id),
+            url_params=dict(name=name) if name else dict(id=model_id),
         )
 
     def model_output_update(

--- a/meorg_client/tests/test_client.py
+++ b/meorg_client/tests/test_client.py
@@ -156,15 +156,21 @@ class TestModelOutput:
         model_output_id = response.get("data").get("modeloutput")
         assert model_output_id is not None
 
-        self.test_model_output_query(client, model_output_id)
-
-    def test_model_output_query(self, client: Client, model_output_id: str):
+    def test_model_output_query(self, client: Client, model_output_name: str, model_output_generator):
         """Test Existing Model output."""
-        response = client.model_output_query(model_output_id)
+
+        id = model_output_generator(model_output_name)
+        response = client.model_output_query(model_id=id)
         assert client.success()
 
         response_model_output_data = response.get("data").get("modeloutput")
-        assert response_model_output_data.get("id") == model_output_id
+        assert response_model_output_data.get("id") == id
+
+        response = client.model_output_query(model_output_name, name=model_output_name)
+        assert client.success()
+
+        response_model_output_data = response.get("data").get("modeloutput")
+        assert response_model_output_data.get("id") == id
 
     def test_model_output_update(
         self,


### PR DESCRIPTION
The `/modeloutput` get endpoint requires specifying the `name` key when querying by name however meorg_client is currently fixed to always query by id.

This change adds a `--name` argument to `meorg output query` to allow for querying a model output by its name. For example:

    meorg output query --name my-model-output

This change also updates the `model_id` argument to `meorg output query` to be optional as a way to preserve the existing signature of the command but still allow querying solely by the `--name` argument.
